### PR TITLE
chore: add data/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 output
+data/


### PR DESCRIPTION
## Summary
- Add `data/` to .gitignore so converted files and history.json are not committed.
- Temp directory was not in .gitignore; uploads use memoryStorage, so no temp entry to remove.

Closes #8

Made with [Cursor](https://cursor.com)