### PR TITLE
feat: convert endpoint multi-file uuid and history

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import bodyParser from 'body-parser'
+import crypto from 'crypto'
 import express from 'express'
 import fs from 'fs'
 import path from 'path'
@@ -9,14 +10,14 @@ const app = express()
 const APP_PORT = process.env.PORT || 8080
 
 const DATA_DIR = process.env.DATA_DIR || 'data'
+const OUTPUT_DIR = path.join(DATA_DIR, 'output')
 const HISTORY_PATH = path.join(DATA_DIR, 'history.json')
 
 if (!fs.existsSync(DATA_DIR)) {
   fs.mkdirSync(DATA_DIR, { recursive: true })
 }
-const dataOutputDir = path.join(DATA_DIR, 'output')
-if (!fs.existsSync(dataOutputDir)) {
-  fs.mkdirSync(dataOutputDir, { recursive: true })
+if (!fs.existsSync(OUTPUT_DIR)) {
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true })
 }
 if (!fs.existsSync(HISTORY_PATH)) {
   fs.writeFileSync(HISTORY_PATH, '{}', 'utf8')
@@ -30,18 +31,37 @@ if (!fs.existsSync(PUBLIC_OUTPUT)) {
 app.use(express.static('public'))
 app.use(bodyParser.json())
 
-app.post(
-  '/convert',
-  multer({ storage: multer.memoryStorage() }).single('file'),
-  async (req, res) => {
-    const file = req.file
-    if (!file) throw new Error('No file provided')
+const MAX_FILES = 20
+const converter = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+}).array('file', MAX_FILES)
 
-    const filename = file.originalname.replace(/\.\w+$/, '.webp')
-    await sharp(file.buffer).webp().toFile(path.join(PUBLIC_OUTPUT, filename))
-    res.json({ filename })
-  },
-)
+app.post('/convert', converter, async (req, res) => {
+  const files = req.files as Express.Multer.File[] | undefined
+  if (!files?.length) throw new Error('No file provided')
+
+  const history: Record<string, { originalName: string; createdAt: string }> =
+    JSON.parse(fs.readFileSync(HISTORY_PATH, 'utf8'))
+
+  const result: { id: string; originalName: string }[] = []
+
+  for (const file of files) {
+    const id = crypto.randomUUID()
+    const originalName = file.originalname.replace(/\.\w+$/, '.webp')
+    await sharp(file.buffer)
+      .webp()
+      .toFile(path.join(OUTPUT_DIR, `${id}.webp`))
+    history[id] = {
+      originalName,
+      createdAt: new Date().toISOString(),
+    }
+    result.push({ id, originalName })
+  }
+
+  fs.writeFileSync(HISTORY_PATH, JSON.stringify(history, null, 2), 'utf8')
+  res.json({ files: result })
+})
 
 app.get('/download/:filename', (req, res) => {
   if (!req.params.filename) throw new Error('No specified file name found.')


### PR DESCRIPTION
## Summary
- Multer memoryStorage + array('file', 20), 10MB file size limit per file
- Save each file as `UUID.webp` in `data/output`
- Append `uuid -> { originalName, createdAt }` to `data/history.json`
- Response: `{ files: [ { id, originalName } ] }`

Closes #6

Made with [Cursor](https://cursor.com)